### PR TITLE
Targeting OpenGL 3.2 (OpenHoW)

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -27,6 +27,9 @@ For more information, please refer to <http://unlicense.org>
 
 project(OpenHoW)
 
+#Required for OpenGL3.x imgui setup
+add_definitions("-DIMGUI_IMPL_OPENGL_LOADER_GLEW")
+
 file(
         GLOB OPENHOW_SOURCE_FILES
         *.cpp *.c
@@ -56,8 +59,8 @@ file(
         ../3rdparty/imgui/imgui_draw.cpp
         ../3rdparty/imgui/imgui_widgets.cpp
         #../3rdparty/imgui/imgui_demo.cpp
-        ../3rdparty/imgui/examples/imgui_impl_opengl2.cpp
-        ../3rdparty/imgui/examples/imgui_impl_opengl2.h
+        ../3rdparty/imgui/examples/imgui_impl_opengl3.cpp
+        ../3rdparty/imgui/examples/imgui_impl_opengl3.h
         ../3rdparty/imgui_tabs/imgui_tabs.cpp
         )
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -69,7 +69,12 @@ add_executable(OpenHoW ${OPENHOW_SOURCE_FILES})
 if(WIN32)
     add_dependencies(OpenHoW OpenAL)
 
-    target_include_directories(OpenHoW PRIVATE ../3rdparty/SDL2/include/ ../3rdparty/openal-soft/include/)
+    target_include_directories(OpenHoW PRIVATE
+            ../3rdparty/SDL2/include/
+            ../3rdparty/openal-soft/include/
+            # below is hack to get imgui compiled on Windows with GLEW.
+            ../3rdparty/platform/platform/3rdparty/glew-2.2.0/include/
+            )
     target_link_directories(OpenHoW PRIVATE ../3rdparty/SDL2/lib/ ../3rdparty/openal-soft/lib/ ../../lib/)
     target_link_options(OpenHoW PRIVATE -mwindows)
     target_link_libraries(OpenHoW -Wl,-Bstatic SDL2 OpenAL32 stdc++ winpthread -Wl,-Bdynamic -static-libstdc++ -static-libgcc

--- a/src/engine/client/display.h
+++ b/src/engine/client/display.h
@@ -50,6 +50,7 @@ int Display_GetViewportHeight(const PLViewport *viewport);
 void Display_SetupDraw(double delta);
 void Display_DrawScene(void);
 void Display_DrawInterface(void);
+void Display_Composite(void);
 void Display_Flush(void);
 
 void Display_ClearTextureIndex(unsigned int id);

--- a/src/engine/client/display.h
+++ b/src/engine/client/display.h
@@ -50,6 +50,7 @@ int Display_GetViewportHeight(const PLViewport *viewport);
 void Display_SetupDraw(double delta);
 void Display_DrawScene(void);
 void Display_DrawInterface(void);
+void Display_DrawDebug(void);
 void Display_Composite(void);
 void Display_Flush(void);
 

--- a/src/engine/client/font.c
+++ b/src/engine/client/font.c
@@ -185,7 +185,7 @@ BitmapFont *LoadBitmapFont(const char *name, const char *tab_name) {
 //////////////////////////////////////////////////////////////////////////
 
 void CacheFontData(void) {
-    font_mesh = plCreateMesh(PL_MESH_TRIANGLE_STRIP, PL_DRAW_IMMEDIATE, 2, 4);
+    font_mesh = plCreateMesh(PL_MESH_TRIANGLE_STRIP, PL_DRAW_DYNAMIC, 2, 4);
     if(font_mesh == NULL) {
         Error("failed to create font mesh, %s, aborting!\n", plGetError());
     }

--- a/src/engine/client/frontend.c
+++ b/src/engine/client/frontend.c
@@ -378,8 +378,6 @@ void FE_Draw(void) {
             } break;
         }
     }
-
-    plDrawPerspectivePOST(g_state.ui_camera);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * */

--- a/src/engine/client/frontend.c
+++ b/src/engine/client/frontend.c
@@ -229,7 +229,7 @@ void FE_Simulate(void) {
 char loading_description[256];
 uint8_t loading_progress = 0;
 
-#define Redraw()   FE_Draw();
+#define Redraw()   Display_DrawInterface();
 
 void FE_SetLoadingBackground(const char *name) {
     if(fe_background != NULL) {

--- a/src/engine/client/shader.c
+++ b/src/engine/client/shader.c
@@ -22,11 +22,11 @@
 #include "shader.h"
 
 #define GLSL(...) #__VA_ARGS__
-#define GLSL_DEFAULT_UNIFORMS \
-        "uniform sampler2D diffuse;"
+#define GLSL_DEFAULT_VS_UNIFORMS "attribute vec3 pos; attribute vec3 norm; attribute vec2 UV; attribute vec4 col;"
+#define GLSL_DEFAULT_PS_UNIFORMS "uniform sampler2D diffuse;"
 
 static const char *fragment_water =
-        GLSL_DEFAULT_UNIFORMS
+        GLSL_DEFAULT_PS_UNIFORMS
         GLSL(
                 void main() {
                     gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
@@ -34,7 +34,7 @@ static const char *fragment_water =
         );
 
 static const char *vertex_water =
-        GLSL_DEFAULT_UNIFORMS
+        GLSL_DEFAULT_VS_UNIFORMS
         GLSL(
                 attribute vec2 position;
 
@@ -44,41 +44,75 @@ static const char *vertex_water =
                 }
         );
 
-static const char *fragment_default =
-        GLSL_DEFAULT_UNIFORMS
+static const char *fragment_colour =
+        GLSL_DEFAULT_PS_UNIFORMS
         GLSL(
-                varying vec4 v_colour;
+                in vec3 interp_normal;
+                in vec2 interp_UV;
+                in vec4 interp_colour;
 
                 void main() {
-                    gl_FragColor = v_colour * texture2D(diffuse, gl_TexCoord[0].st);
+                    gl_FragColor = interp_colour;
                 }
         );
 
-static const char *fragment_alpha_test =
-        GLSL_DEFAULT_UNIFORMS
+static const char *fragment_texture =
+        GLSL_DEFAULT_PS_UNIFORMS
         GLSL(
-                varying vec4 v_colour;
+                in vec3 interp_normal;
+                in vec2 interp_UV;
+                in vec4 interp_colour;
 
                 void main() {
-                    vec4 colour = texture2D(diffuse, gl_TexCoord[0].st);
-                    if(colour.a < 0.1) {
+                    gl_FragColor = interp_colour * texture2D(diffuse, interp_UV);
+                }
+        );
+
+static const char *fragment_alpha_test_texture =
+        GLSL_DEFAULT_PS_UNIFORMS
+        GLSL(
+                in vec3 interp_normal;
+                in vec2 interp_UV;
+                in vec4 interp_colour;
+
+                void main() {
+                    vec4 sample = texture2D(diffuse, interp_UV);
+                    if(sample.a < 0.1) {
                         discard;
                     }
 
-                    gl_FragColor = v_colour * colour;
+                    gl_FragColor = interp_colour * sample;
                 }
         );
 
 static const char *vertex_default =
-        GLSL_DEFAULT_UNIFORMS
+        GLSL_DEFAULT_VS_UNIFORMS
         GLSL(
-                varying vec4 v_colour;
+                out vec3 interp_normal;
+                out vec2 interp_UV;
+                out vec4 interp_colour;
 
                 void main() {
-                    v_colour = gl_Color;
+                    gl_Position = proj * modelView * vec4(pos, 1.0f);
+                    interp_normal = norm;
+                    interp_UV = UV;
+                    interp_colour = col;
+                }
+        );
 
-                    gl_TexCoord[0] = gl_MultiTexCoord0;
-                    gl_Position = ftransform();
+static const char *vertex_debug_test =
+        GLSL_DEFAULT_VS_UNIFORMS
+        GLSL(
+                void main() {
+                    gl_Position = proj * modelView * vec4(pos, 1.0f);
+                }
+        );
+
+static const char *fragment_debug_test =
+        GLSL_DEFAULT_PS_UNIFORMS
+        GLSL(
+                void main() {
+                    gl_FragColor = vec4(1.0f, 0.0f, 1.0f, 1.0f);
                 }
         );
 
@@ -124,13 +158,15 @@ static PLShaderProgram *CreateShaderProgram(const char *vertex, size_t vl, const
 
 void Shaders_Initialize(void) {
     memset(programs, 0, sizeof(PLShaderProgram*) * MAX_SHADERS);
-    programs[SHADER_DEFAULT]    = CreateShaderProgram(vertex_default, strlen(vertex_default),
-                                                      fragment_default, strlen(fragment_default));
-    programs[SHADER_WATER]      = CreateShaderProgram(vertex_water, strlen(vertex_water),
-                                                      fragment_water, strlen(fragment_water));
-    programs[SHADER_ALPHA_TEST] = CreateShaderProgram(vertex_default, strlen(vertex_default),
-                                                      fragment_alpha_test, strlen(fragment_alpha_test));
+    programs[SHADER_DEFAULT]    = CreateShaderProgram(vertex_default, strlen(vertex_default), fragment_texture, strlen(fragment_texture));
+    programs[SHADER_WATER]      = CreateShaderProgram(vertex_default, strlen(vertex_default), fragment_water, strlen(fragment_water));
+    programs[SHADER_ALPHA_TEST] = CreateShaderProgram(vertex_default, strlen(vertex_default), fragment_alpha_test_texture, strlen(fragment_alpha_test_texture));
     //programs[SHADER_VIDEO]      = CreateShaderProgram("video", "video");
+    programs[SHADER_DEBUG_TEST]       = CreateShaderProgram(vertex_debug_test, strlen(vertex_debug_test), fragment_debug_test, strlen(fragment_debug_test));
+
+
+
+
 
     /* set defaults */
     for(unsigned int i = 0; i < MAX_SHADERS; ++i) {

--- a/src/engine/client/shader.c
+++ b/src/engine/client/shader.c
@@ -93,7 +93,7 @@ static const char *vertex_default =
                 out vec4 interp_colour;
 
                 void main() {
-                    gl_Position = proj * modelView * vec4(pos, 1.0f);
+                    gl_Position = pl_proj * pl_model_view * vec4(pos, 1.0f);
                     interp_normal = norm;
                     interp_UV = UV;
                     interp_colour = col;
@@ -104,7 +104,7 @@ static const char *vertex_debug_test =
         GLSL_DEFAULT_VS_UNIFORMS
         GLSL(
                 void main() {
-                    gl_Position = proj * modelView * vec4(pos, 1.0f);
+                    gl_Position = pl_proj * pl_model_view * vec4(pos, 1.0f);
                 }
         );
 

--- a/src/engine/client/shader.h
+++ b/src/engine/client/shader.h
@@ -101,6 +101,7 @@ enum {
     SHADER_ALPHA_TEST,  /* */
     SHADER_WATER,       /* */
     SHADER_VIDEO,       /* */
+    SHADER_DEBUG_TEST,
 
     MAX_SHADERS
 };

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -117,6 +117,7 @@ void System_SwapDisplay(void);
 
 void System_SetWindowTitle(const char *title);
 void System_GetWindowSize(int *width, int *height, bool *fs);
+void System_GetWindowDrawableSize(int *width, int *height, bool *fs);
 bool System_SetWindowSize(int *width, int *height, bool fs);
 
 void System_Shutdown(void);

--- a/src/engine/model.c
+++ b/src/engine/model.c
@@ -701,7 +701,7 @@ void DEBUGDrawSkeleton(void) {
 
     static PLMesh *skeleton_mesh = NULL;
     if(skeleton_mesh == NULL) {
-        skeleton_mesh = plCreateMesh(PL_MESH_LINES, PL_DRAW_IMMEDIATE, 0, model_cache.num_bones * 2);
+        skeleton_mesh = plCreateMesh(PL_MESH_LINES, PL_DRAW_DYNAMIC, 0, model_cache.num_bones * 2);
     }
 
 #if 0

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -571,6 +571,7 @@ int main(int argc, char **argv) {
         Display_DrawScene();
         Display_DrawInterface();
         Display_Composite();
+        Display_DrawDebug();
 
         /* now render imgui */
         ImGui::Render();

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -23,7 +23,7 @@
 #include "imgui_layer.h"
 
 #include "../3rdparty/imgui/examples/imgui_impl_sdl.h"
-#include "../3rdparty/imgui/examples/imgui_impl_opengl2.h"
+#include "../3rdparty/imgui/examples/imgui_impl_opengl3.h"
 
 #include "server/server.h"
 #include "client/display.h"
@@ -97,9 +97,10 @@ void System_DisplayWindow(bool fullscreen, int width, int height) {
 #if 1
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 #endif
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    //SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
 #if 1
     if(SDL_GL_SetSwapInterval(-1) != 0) {
@@ -176,7 +177,7 @@ void System_DisplayWindow(bool fullscreen, int width, int height) {
     io.ImeWindowHandle = wmInfo.info.win.window;
 #endif
 
-    ImGui_ImplOpenGL2_Init();
+    ImGui_ImplOpenGL3_Init();
 
     ImGui::StyleColorsDark();
 }
@@ -187,6 +188,11 @@ void System_SetWindowTitle(const char *title) {
 
 void System_GetWindowSize(int *width, int *height, bool *fs) {
     SDL_GetWindowSize(window, width, height);
+    *fs = static_cast<bool>(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN);
+}
+
+void System_GetWindowDrawableSize(int *width, int *height, bool *fs) {
+    SDL_GL_GetDrawableSize(window, width, height);
     *fs = static_cast<bool>(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN);
 }
 
@@ -227,7 +233,7 @@ void System_SwapDisplay(void) {
 void System_Shutdown(void) {
     Engine_Shutdown();
 
-    ImGui_ImplOpenGL2_DestroyDeviceObjects();
+    ImGui_ImplOpenGL3_DestroyDeviceObjects();
     ImGui::DestroyContext();
 
     SDL_StopTextInput();
@@ -556,7 +562,7 @@ int main(int argc, char **argv) {
         Client_Render(delta_time);
 #else
 
-        ImGui_ImplOpenGL2_NewFrame();
+        ImGui_ImplOpenGL3_NewFrame();
         ImGui::NewFrame();
 
         delta_time = (double)(System_GetTicks() + SKIP_TICKS - next_tick) / (double)(SKIP_TICKS);
@@ -564,15 +570,15 @@ int main(int argc, char **argv) {
 
         Display_DrawScene();
         Display_DrawInterface();
+        Display_Composite();
 
         /* now render imgui */
-
         ImGui::Render();
 
         plSetupCamera(imgui_camera);
         plSetShaderProgram(nullptr);
 
-        ImGui_ImplOpenGL2_RenderDrawData(ImGui::GetDrawData());
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
         /* and finally, swap */
 


### PR DESCRIPTION
- Updated OpenGL context to 3.2 core / GLSL #150
- Removed deprecated OpenGL 2.2 fixed function pipeline calls, all meshes now render as dynamic_draw VBO buffers
- Detached render target management from camera class
- Made "Ingame" and "Frontend" scenes to render to seperate internal 640x480 targets, laying the groundwork for configurable internal resolution
- Added new platform functions to create, destroy, bind, and blit  platform framebuffer objects
